### PR TITLE
Add woff/woff2 versions of fonts stored on S3

### DIFF
--- a/my-app/src/1821-fonts.css
+++ b/my-app/src/1821-fonts.css
@@ -1,0 +1,123 @@
+/* eczar-regular - latin */
+@font-face {
+  font-family: "Eczar";
+  font-style: normal;
+  font-weight: 400;
+  src: local(""),
+    url("https://interactive.guim.co.uk/fonts/1821-mode/eczar-v9-latin-regular.woff2")
+      format("woff2"),
+    /* Chrome 26+, Opera 23+, Firefox 39+ */
+      url("https://interactive.guim.co.uk/fonts/1821-mode/eczar-v9-latin-regular.woff")
+      format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+}
+/* eczar-600 - latin */
+@font-face {
+  font-family: "Eczar";
+  font-style: normal;
+  font-weight: 600;
+  src: local(""),
+    url("https://interactive.guim.co.uk/fonts/1821-mode/eczar-v9-latin-600.woff2")
+      format("woff2"),
+    /* Chrome 26+, Opera 23+, Firefox 39+ */
+      url("https://interactive.guim.co.uk/fonts/1821-mode/eczar-v9-latin-600.woff")
+      format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+}
+/* eczar-500 - latin */
+@font-face {
+  font-family: "Eczar";
+  font-style: normal;
+  font-weight: 500;
+  src: local(""),
+    url("https://interactive.guim.co.uk/fonts/1821-mode/eczar-v9-latin-500.woff2")
+      format("woff2"),
+    /* Chrome 26+, Opera 23+, Firefox 39+ */
+      url("https://interactive.guim.co.uk/fonts/1821-mode/eczar-v9-latin-500.woff")
+      format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+}
+/* eczar-700 - latin */
+@font-face {
+  font-family: "Eczar";
+  font-style: normal;
+  font-weight: 700;
+  src: local(""),
+    url("https://interactive.guim.co.uk/fonts/1821-mode/eczar-v9-latin-700.woff2")
+      format("woff2"),
+    /* Chrome 26+, Opera 23+, Firefox 39+ */
+      url("https://interactive.guim.co.uk/fonts/1821-mode/eczar-v9-latin-700.woff")
+      format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+}
+/* eczar-800 - latin */
+@font-face {
+  font-family: "Eczar";
+  font-style: normal;
+  font-weight: 800;
+  src: local(""),
+    url("https://interactive.guim.co.uk/fonts/1821-mode/eczar-v9-latin-800.woff2")
+      format("woff2"),
+    /* Chrome 26+, Opera 23+, Firefox 39+ */
+      url("https://interactive.guim.co.uk/fonts/1821-mode/eczar-v9-latin-800.woff")
+      format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+}
+
+/* im-fell-english-sc-regular - latin */
+@font-face {
+  font-family: "IM Fell English SC";
+  font-style: normal;
+  font-weight: 400;
+  src: local(""),
+    url("https://interactive.guim.co.uk/fonts/1821-mode/im-fell-english-sc-v12-latin-regular.woff2")
+      format("woff2"),
+    /* Chrome 26+, Opera 23+, Firefox 39+ */
+      url("https://interactive.guim.co.uk/fonts/1821-mode/im-fell-english-sc-v12-latin-regular.woff")
+      format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+}
+
+/* lusitana-regular - latin */
+@font-face {
+  font-family: "Lusitana";
+  font-style: normal;
+  font-weight: 400;
+  src: local(""),
+    url("https://interactive.guim.co.uk/fonts/1821-mode/lusitana-v8-latin-regular.woff2")
+      format("woff2"),
+    /* Chrome 26+, Opera 23+, Firefox 39+ */
+      url("https://interactive.guim.co.uk/fonts/1821-mode/lusitana-v8-latin-regular.woff")
+      format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+}
+/* lusitana-700 - latin */
+@font-face {
+  font-family: "Lusitana";
+  font-style: normal;
+  font-weight: 700;
+  src: local(""),
+    url("https://interactive.guim.co.uk/fonts/1821-mode/lusitana-v8-latin-700.woff2")
+      format("woff2"),
+    /* Chrome 26+, Opera 23+, Firefox 39+ */
+      url("https://interactive.guim.co.uk/fonts/1821-mode/lusitana-v8-latin-700.woff")
+      format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+}
+
+/* newsreader-regular - latin */
+@font-face {
+  font-family: "Newsreader";
+  font-style: normal;
+  font-weight: 400;
+  src: local(""),
+    url("https://interactive.guim.co.uk/fonts/1821-mode/newsreader-v7-latin-regular.woff2")
+      format("woff2"),
+    /* Chrome 26+, Opera 23+, Firefox 39+ */
+      url("https://interactive.guim.co.uk/fonts/1821-mode/newsreader-v7-latin-regular.woff")
+      format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+}
+/* newsreader-italic - latin */
+@font-face {
+  font-family: "Newsreader";
+  font-style: italic;
+  font-weight: 400;
+  src: local(""),
+    url("https://interactive.guim.co.uk/fonts/1821-mode/newsreader-v7-latin-italic.woff2")
+      format("woff2"),
+    /* Chrome 26+, Opera 23+, Firefox 39+ */
+      url("https://interactive.guim.co.uk/fonts/1821-mode/newsreader-v7-latin-italic.woff")
+      format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+}

--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -1,8 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=UnifrakturCook:wght@700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Lusitana:wght@400;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Newsreader:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400;1,500;1,600;1,700;1,800&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Eczar:wght@400;500;600;700;800&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=IM+Fell+English+SC&family=IM+Fell+English:ital@0;1&display=swap');
+@import './1821-fonts.css';
 
 /* DEFAULT STYLING (MOBILE) */
 


### PR DESCRIPTION
## What does this change?
Woff/woff2 has better compression than the TFF format.

The fonts are now stored on S3 instead of directly from Google fonts.