### PR TITLE
add drop cap to first paragraph of each story

### DIFF
--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -57,6 +57,19 @@ p {
     font-size: 0.8em;
 }
 
+.story-copy p:first-child::first-letter {
+  font-family: "IM Fell English SC";
+  font-size: 2rem;
+  float: left;
+  line-height: 1;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.story-copy p:first-child {
+    text-indent: 0em;
+}
+
 a {
     color: black;
 }


### PR DESCRIPTION
## What does this change?
This changes the styling of the first letter of each story to be a drop cap, mimicking the original paper.

## Images
**Original paper**

![image](https://user-images.githubusercontent.com/57295823/116702960-9ba50e80-a9c1-11eb-96dc-63299786aa88.png) 

**1821 mode**

![image](https://user-images.githubusercontent.com/57295823/116703039-b4adbf80-a9c1-11eb-8e6e-078254210332.png)
