### PR TITLE
Add header font saved on S3

### DIFF
--- a/my-app/src/1821-fonts.css
+++ b/my-app/src/1821-fonts.css
@@ -121,3 +121,15 @@
       url("https://interactive.guim.co.uk/fonts/1821-mode/newsreader-v7-latin-italic.woff")
       format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
+/* unifrakturcook-700 - latin */
+@font-face {
+  font-family: "UnifrakturCook";
+  font-style: normal;
+  font-weight: 700;
+  src: local(""),
+    url("https://interactive.guim.co.uk/fonts/1821-mode/unifrakturcook-v14-latin-700.woff2")
+      format("woff2"),
+    /* Chrome 26+, Opera 23+, Firefox 39+ */
+      url("https://interactive.guim.co.uk/fonts/1821-mode/unifrakturcook-v14-latin-700.woff")
+      format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+}


### PR DESCRIPTION
## What does this change?
Adds the font for header 'The Manchester Guardian' to 1821-fonts.css.

## Images
![image](https://user-images.githubusercontent.com/7883129/116783911-492f2500-aa89-11eb-9f50-df4e9ddcff05.png)
