### PR TITLE
Allow twitter to crawl

### DIFF
--- a/my-app/public/robots.txt
+++ b/my-app/public/robots.txt
@@ -1,3 +1,6 @@
 # https://www.robotstxt.org/robotstxt.html
-User-agent: *
+User-agent: Twitterbot
 Disallow:
+
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Adding ability for twitter to crawl the site for social share metadata. Also disallows all other crawlers.